### PR TITLE
python_base: pin node-sass

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -43,7 +43,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         wget && \
     yum clean all
 RUN npm install -g \
-        node-sass \
+        node-sass@3.8.0 \
         clean-css \
         requirejs \
         uglify-js


### PR DESCRIPTION
Pinning `node-sass@3.8.0` prevents https://github.com/inspirehep/inspire-next/issues/1642 from happening.

Closes https://github.com/inspirehep/inspire-next/issues/1642