### PR TITLE
elasticsearch: mapper-attachments plugin addition

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -25,4 +25,5 @@ FROM elasticsearch:2.4.1
 RUN plugin install analysis-icu && \
     plugin install mobz/elasticsearch-head && \
     plugin install royrusso/elasticsearch-HQ && \
-    plugin install analysis-phonetic
+    plugin install analysis-phonetic && \
+    plugin install -b mapper-attachments


### PR DESCRIPTION
* Needed by invenio-records-files>=v1.0.0a8.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>