### PR TITLE
readme: fix the command line for the docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Building the images is as easy as running the docker build with the appropiate
 tag, for example:
 
 ```shell
-docker build -f python_base/Dockerfile -t inspirehep/python-base
+docker build -f python_base/Dockerfile -t inspirehep/python-base .
 ```
 
 Or alternatively run the build script, setting up any required env vars (see


### PR DESCRIPTION
The `docker build` was missing a dot. 