### PR TITLE
python_base: remove inspire pkg stable deps file

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -59,13 +59,17 @@ RUN virtualenv /tmpvenv -p python${INSPIRE_PYTHON_VERSION} && \
     wget -q https://raw.githubusercontent.com/inspirehep/inspire-next/master/requirements.txt && \
     wget -q https://raw.githubusercontent.com/inspirehep/inspire-next/master/setup.py && \
     wget -q https://raw.githubusercontent.com/inspirehep/inspire-next/master/README.rst && \
-    mkdir inspirehep/ && cd inspirehep/ && \
-    wget -q https://raw.githubusercontent.com/inspirehep/inspire-next/master/inspirehep/version.py && cd /tmp && \
+    mkdir inspirehep/ && \
+    cd inspirehep/ && \
+    wget -q https://raw.githubusercontent.com/inspirehep/inspire-next/master/inspirehep/version.py && \
+    cd /tmp && \
     egrep -v '^-e \.\[[a-z]+\]$' requirements.txt >> requirements-all.txt && \
     requirements-builder setup.py -e all -e postgresql >> requirements-all.txt && \
     pip wheel --wheel-dir /pip-cache -r requirements-all.txt --pre && \
     pip install --find-links /pip-cache -r requirements.txt --pre -e .[tests,crawler] gunicorn --exists-action i && \
-    pip uninstall -y Inspirehep && mkdir /deps && pip freeze > /deps/deps.txt && \
+    pip uninstall -y Inspirehep && \
+    mkdir /deps && \
+    pip freeze > /deps/deps.txt && \
     deactivate && \
     mv /tmpvenv/src /src-cache && \
     rm -rf /tmpvenv && \

--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -65,7 +65,7 @@ RUN virtualenv /tmpvenv -p python${INSPIRE_PYTHON_VERSION} && \
     requirements-builder setup.py -e all -e postgresql >> requirements-all.txt && \
     pip wheel --wheel-dir /pip-cache -r requirements-all.txt --pre && \
     pip install --find-links /pip-cache -r requirements.txt --pre -e .[tests,crawler] gunicorn --exists-action i && \
-    mkdir /deps && pip freeze > /deps/deps.txt && \
+    pip uninstall -y Inspirehep && mkdir /deps && pip freeze > /deps/deps.txt && \
     deactivate && \
     mv /tmpvenv/src /src-cache && \
     rm -rf /tmpvenv && \


### PR DESCRIPTION
This change should remove the `inspirehep` package. It is necessary to run the tests for this PR (https://github.com/inspirehep/inspire-next/pull/1810). Now the tests are failing because `pip` is trying to install the package of `Inspirehep` https://travis-ci.org/inspirehep/inspire-next/jobs/183907796.