### PR TITLE
python_base: add mailcap

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -31,6 +31,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         libffi-devel \
         libxml2-devel \
         libxslt-devel \
+        mailcap \
         nodejs \
         npm \
         openssl-devel \


### PR DESCRIPTION
@david-caro made me realize that the reason `inspire-nightly` does not serve SVGs is because it does not know about them : )