### PR TITLE
python_base: fix failing build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export TRAVIS_BRANCH=master
 export DOCKER_PROJECT=inspirehep/python-base
 export DOCKER_IMAGE_TAG=latest
 export DOCKERFILE=python_base/Dockerfile
-ARGS='--build-arg=INSPIRE_PYTHON_VERSION=2.7'
+export ARGS='--build-arg=INSPIRE_PYTHON_VERSION=2.7'
 ./build.sh --help
 ./build.sh
 ```

--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -55,7 +55,8 @@ ENV INSPIRE_PYTHON_VERSION ${INSPIRE_PYTHON_VERSION:-2.7}
 
 RUN virtualenv /tmpvenv -p python${INSPIRE_PYTHON_VERSION} && \
     . /tmpvenv/bin/activate && \
-    pip install --upgrade pip setuptools wheel && \
+    pip install --upgrade pip && \
+    pip install --upgrade setuptools wheel && \
     pip install --upgrade requirements-builder && \
     cd /tmp && \
     wget -q https://raw.githubusercontent.com/inspirehep/inspire-next/master/requirements.txt && \

--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -46,7 +46,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     yum clean all
 RUN npm install -g \
         node-sass@3.8.0 \
-        clean-css \
+        clean-css@^3.4.23 \
         requirejs \
         uglify-js
 

--- a/python_base/docker_entrypoint.sh
+++ b/python_base/docker_entrypoint.sh
@@ -27,7 +27,8 @@ set -e
 if [ ! -f /virtualenv/bin/activate ]; then
     virtualenv /virtualenv -p python${INSPIRE_PYTHON_VERSION}
     source /virtualenv/bin/activate
-    pip install --upgrade pip setuptools wheel
+    pip install --upgrade pip
+    pip install --upgrade setuptools wheel
     cp -r /src-cache /virtualenv/src
 else
     source /virtualenv/bin/activate

--- a/test.sh
+++ b/test.sh
@@ -188,11 +188,13 @@ main() {
         CUR_TAG="$DOCKER_PROJECT:dev.$TRAVIS_BRANCH-$DOCKER_IMAGE_TAG"
         echo "Adding tag $TEST_TAG to the image for the testing"
         docker tag "$CUR_TAG" "$TEST_TAG"
-        if [[ "$DOCKER_IMAGE_TAG" != "latest" ]]; then
-            LATEST_TAG="$DOCKER_PROJECT:latest"
-            echo "Adding latest tag $LATEST_TAG to the image for the testing"
-            docker tag "$CUR_TAG" "$LATEST_TAG"
-        fi
+    else
+        CUR_TAG="$DOCKER_PROJECT:$DOCKER_IMAGE_TAG"
+    fi
+    if [[ "$DOCKER_IMAGE_TAG" != "latest" ]]; then
+        LATEST_TAG="$DOCKER_PROJECT:latest"
+        echo "Adding latest tag $LATEST_TAG to the image for the testing"
+        docker tag "$CUR_TAG" "$LATEST_TAG"
     fi
     prepare
     pull_all_images_except "$DOCKER_PROJECT"


### PR DESCRIPTION
* Fix bug: it is needed to upgrade to the latest version of `pip`
                before install `setuptools`, otherwise build fails.
* Fix missed documentation.

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>