### PR TITLE
python_base: add make command for makefiles

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -33,6 +33,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         libxml2-devel \
         libxslt-devel \
         mailcap \
+        make \
         nodejs \
         npm \
         openssl-devel \


### PR DESCRIPTION
* Adds `make` command for script that executes unit tests and generates documentation for Inspire-hep.

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>