### PR TITLE
python_base: add docs requirements for install

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -70,7 +70,7 @@ RUN virtualenv /tmpvenv -p python${INSPIRE_PYTHON_VERSION} && \
     egrep -v '^-e \.\[[a-z]+\]$' requirements.txt >> requirements-all.txt && \
     requirements-builder setup.py -e all -e postgresql >> requirements-all.txt && \
     pip wheel --wheel-dir /pip-cache -r requirements-all.txt --pre && \
-    pip install --find-links /pip-cache -r requirements.txt --pre -e .[tests,crawler] gunicorn --exists-action i && \
+    pip install --find-links /pip-cache -r requirements.txt --pre -e .[tests,crawler,docs] gunicorn --exists-action i && \
     pip uninstall -y Inspirehep && \
     mkdir /deps && \
     pip freeze > /deps/deps.txt && \


### PR DESCRIPTION
* Adds `docs` requirements to generate documentation.

Addresses https://github.com/inspirehep/inspire-next/pull/1982

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>