### PR TITLE
elasticsearch: pin version of ElasticHQ

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -24,6 +24,6 @@ FROM elasticsearch:2.4.1
 
 RUN plugin install analysis-icu && \
     plugin install mobz/elasticsearch-head && \
-    plugin install royrusso/elasticsearch-HQ && \
+    plugin install royrusso/elasticsearch-HQ/v2.0.3 && \
     plugin install analysis-phonetic && \
     plugin install -b mapper-attachments


### PR DESCRIPTION
Tonight ElasticHQ updated itself to support Elasticsearch 5, so the build started failing because we require the latest version from `master`. According to the documentation (https://github.com/royrusso/elasticsearch-HQ), `v2.0.3` is the latest to support Elasticsearch 2.