### PR TITLE
python_base: don't fail to start on chown error

### DIFF
--- a/python_base/docker_entrypoint.sh
+++ b/python_base/docker_entrypoint.sh
@@ -71,8 +71,8 @@ prepare_venv() {
 
 
 main() {
-    /fix_rights --virtualenv 'test:test'
-    /fix_rights --codedir 'test:test'
+    /fix_rights --virtualenv 'test:test' || :
+    /fix_rights --codedir 'test:test' || :
     trap restore_venv_rights EXIT
 
     if ! [[ -f "$VENV_PATH/bin/activate" ]]; then
@@ -81,7 +81,7 @@ main() {
         source "$VENV_PATH"/bin/activate
     fi
 
-    find \( -name __pycache__ -o -name '*.pyc' \) -delete
+    find \( -name __pycache__ -o -name '*.pyc' \) -delete || :
 
     trap forward_sigterm SIGTERM
     trap forward_sigint SIGINT


### PR DESCRIPTION
The containers got in a race condition sometimes where the chown tried
to change the ownership of the '.pyc' files while they were removed by
another container, failing to run the docker_entrypoint script and
failing to start the container. Now it will ignore such errors and
just continue running (if there were serious issues, it will fail to
run the tests).

Fixes https://github.com/inspirehep/inspire-next/issues/2385

Signed-off-by: David Caro <david@dcaro.es>