### PR TITLE
python_base: add explicit http-parser dependency

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -21,6 +21,9 @@
 # or submit itself to any jurisdiction.
 FROM centos
 
+# For the strange http-parser dependency, see:
+#     https://bugzilla.redhat.com/show_bug.cgi?id=1481008
+
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum update -y && \
     yum install -y \
@@ -45,7 +48,9 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         python-pip \
         python-virtualenv \
         xrootd-python \
-        wget && \
+        wget \
+        https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm \
+        && \
     yum clean all
 RUN npm install -g \
         node-sass@3.8.0 \


### PR DESCRIPTION
It turns out that the package was moved to rhel 7.4 repos, so it was
removed from epel, will not be needed once the base centos images
are upgraded. See:
https://bugzilla.redhat.com/show_bug.cgi?id=1481008