### PR TITLE
Revert "Fix http-parser missing package"

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -21,9 +21,6 @@
 # or submit itself to any jurisdiction.
 FROM centos
 
-# For the strange http-parser dependency, see:
-#     https://bugzilla.redhat.com/show_bug.cgi?id=1481008
-
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum update -y && \
     yum install -y \
@@ -48,9 +45,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         python-pip \
         python-virtualenv \
         xrootd-python \
-        wget \
-        https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm \
-        && \
+        wget && \
     yum clean all
 RUN npm install -g \
         node-sass@3.8.0 \


### PR DESCRIPTION
This reverts commit 269857081f210bd14b93af0fd3117d0259b0a7c4.

Once the issue on upstream repos is solved, the patch is not needed
anymore.