### PR TITLE
python_base: pin centos to 7.4.1708

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,10 +19,7 @@
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
-FROM centos
-
-# For the strange http-parser dependency, see:
-#     https://bugzilla.redhat.com/show_bug.cgi?id=1481008
+FROM centos:7.4.1708
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum update -y && \
@@ -49,7 +46,6 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         python-virtualenv \
         xrootd-python \
         wget \
-        https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm \
         && \
     yum clean all
 RUN npm install -g \


### PR DESCRIPTION
Makes the workaround introduced in 2698570 obsolete as now the package
is normally available (closes #52).