### PR TITLE
python-base: install missing package to get fig2dev

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -25,6 +25,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     yum update -y && \
     yum install -y \
         ImageMagick \
+        transfig \
         file \
         firefox \
         gcc \


### PR DESCRIPTION
* This was making some harvests fail with the error 'unable to open
  file /tmp/magick-...' as it was actually unable to generate that
  file.

Signed-off-by: David Caro <david@dcaro.es>