### PR TITLE
travis: use deprecated Trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: deprecated-2017Q4
 services:
   - docker
 


### PR DESCRIPTION
Fixes the build by using the older Trusty image, which comes with
an older version of ``docker-ce`` whose ``login`` command still
supports the ``--email`` option.

Clearly the better fix is to remove this option from the script, but I
couldn't figure out which of the three secure variables is storing
the email... https://github.com/inspirehep/inspire-docker/blob/ee9a80dc947e5f60c0c39aaa3215ac572cf1ba3c/.travis.yml#L10-L12