### PR TITLE
python_base: add Xvfb package

### DIFF
--- a/python_base/Dockerfile
+++ b/python_base/Dockerfile
@@ -47,6 +47,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         python-virtualenv \
         xrootd-python \
         wget \
+        Xvfb \
         && \
     yum clean all
 RUN npm install -g \


### PR DESCRIPTION
It's needed to run the selenium tests out of travis.

Signed-off-by: David Caro <david@dcaro.es>