### PR TITLE
fixes typo in Usage string

### DIFF
--- a/python_base/fix_rights.c
+++ b/python_base/fix_rights.c
@@ -52,7 +52,7 @@ int main (int argc, char *argv[]) {
         fprintf(stderr, "Bad option %s.", argv[1]);
         fprintf(
             stderr,
-            "Usage: %s --virtualenv|--codedir <user>:<gorup>\n",
+            "Usage: %s --virtualenv|--codedir <user>:<group>\n",
             argv[0]
         );
         exit(EXIT_FAILURE);


### PR DESCRIPTION
simple typo fix in Usage string, no functional change

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>